### PR TITLE
Create Gear_Cockpit_StarCorps_Dalban.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ https://github.com/BattletechModders/BattleTechModLoader/releases
     starsystemdef_Renfield.json - fixed typo: "Concordant" changed to "Concordat"
     starsystemdef_Samantha.json - fixed typo: "Concordant" changed to "Concordat"
     starsystemdef_Taurus.json - fixed typo: "Concordant" changed to "Concordat"
+	
+### StreamingAssets/data/upgrades/cockpitMods/
+	Gear_Cockpit_StarCorps_Dalban.json = fixed typo: "Morale" changed to "Resolve"
 
 ### StreamingAssets/data/vehicle/
     vehicledef_BULLDOG.json - added Front MG and ammo

--- a/StreamingAssets/data/upgrades/cockpitMods/Gear_Cockpit_StarCorps_Dalban.json
+++ b/StreamingAssets/data/upgrades/cockpitMods/Gear_Cockpit_StarCorps_Dalban.json
@@ -1,0 +1,3 @@
+{
+    "BonusValueA" : "+ 4 Resolve Gain"
+}


### PR DESCRIPTION
Change "morale" to "resolve"

Amechwarrior: Got a cFixes edit from the goon discord:
Comms System+++ still shows + 4 Morale Gain instead of the new Resolve
I assume the other comms sys would have this too.

The others do not have the issue only this one which is new in 1.3 IIRC.